### PR TITLE
Link website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # security-team-blog
 
-## Podman container
+Sources for the blog at https://security.opensuse.org.
+
+## Local development
+
+### Podman container
+
 ```./run-podman```
 
 This will run Jekyll in a Podman container, with the checked out git repository mounted inside. You can access this instance via `http://127.0.0.1:4000`.
 
 Jekyll will reload itself on the fly whenever you make changes.
 
-## Manual installation
+### Manual installation
+
 - Install jekyll:
   ```
   sudo zypper in ruby ruby-devel


### PR DESCRIPTION
Hi,

I noticed it wasn't quite obvious what this repository is used for when browsing the repository, hence this is a simple patch to link the website in the README. Feel free to adjust.

Cheers,
Georg